### PR TITLE
Updated `login_hint_token` as per TWG decision 048

### DIFF
--- a/working/v3.0.0-draft2/ciba-flow/CIBA-login-hint-token-schema.json
+++ b/working/v3.0.0-draft2/ciba-flow/CIBA-login-hint-token-schema.json
@@ -14,6 +14,7 @@
       "required": ["subject_type"],
       "maxProperties": 2,
       "minProperties": 2,
+      "additionalProperties": false,
       "properties": {
         "subject_type": {
           "$id": "/properties/subject/properties/subject_type",
@@ -59,6 +60,67 @@
           "pattern": "^[A-Za-z0-9-_]+\\.[A-Za-z0-9-_]+\\.[A-Za-z0-9-_.+/=]*$"
         }
       }
+    },
+    "aud": {
+      "$id": "#/properties/aud",
+      "title": "The audiences for the login hint token",
+      "description": "The value should be or include the API Provider Issuer Identifier URL",
+      "oneOf": [
+        {
+          "type": "string",
+          "examples": ["https://api.alphanbank.com"],
+          "format": "uri"
+        },
+        {
+          "type": "array",
+          "$id": "#/properties/aud/items",
+          "items": {
+            "type": "string",
+            "pattern": "^(.+)$"
+          },
+          "examples": ["https://api.alphanbank.com"]
+        }
+      ]
+    },
+    "iat":{
+      "$id": "/properties/iat",
+      "type": "integer",
+      "description": "Time on which the login hint token was issued. May be used for determining age",
+      "examples": [1496397168]
+    },
+    "exp": {
+      "$id": "/properties/exp",
+      "type": "integer",
+      "description": "Expiration time on or after which the login hint token SHOULD NOT be accepted for processing.",
+      "examples": [1496397168]
+    },
+    "nbf": {
+      "$id": "/properties/nbf",
+      "type": "integer",
+      "description": "Time before which the login hint token SHOULD NOT be accepted for processing.",
+      "examples": [1496397168]
+    },
+    "iss": {
+      "$id": "#/properties/iss",
+      "type": "string",
+      "title": "The Issuer of the token",
+      "description": "The value should be the client ID of the third party, unless signed by a different party",
+      "default": "",
+      "examples": ["s6BhdRkqt3"],
+      "pattern": "^(.+)$"
+    },
+    "jti": {
+      "$id": "#/properties/jti",
+      "type": "string",
+      "title": "The unique identifier of the token",
+      "description": "Used for determining token uniqueness. The value should be have sufficient entropy to make likelihood of collisions negligible.",
+      "examples": ["d92f1393-752e-49c2-8ce3-90abc6b29655"]
+    },
+    "sub": {
+      "$id": "/properties/sub",
+      "type": "string",
+      "description": "Subject Identifier, optionally to be consumed by the API provider",
+      "examples": ["AItOawmwtWwcT0k51BayewNvutrJUqsvl6qs7A4"]
     }
   }
 }

--- a/working/v3.0.0-draft2/common/JOSE-header-schema.json
+++ b/working/v3.0.0-draft2/common/JOSE-header-schema.json
@@ -27,6 +27,13 @@
       "description": "Used to denote the media type of the signed token. If included, the value must be 'JWT' or 'secevent+jwt' for event notifications .",
       "enum": ["JWT", "secevent+jwt"],
       "examples": ["JWT"]
+    },
+    "jku": {
+      "$id": "/properties/jku",
+      "type": "string",
+      "format": "uri",
+      "description": "A hint as to the the location of the signing party's JWKS.  This SHOULD be populated and MUST checked against registered endpoints.",
+      "examples": ["https://example.co.nz/jwk.json"]
     }
   }
 }


### PR DESCRIPTION
This PR includes the updates to `login_hint_token` as a result of [TWG Decision 048](https://paymentsnz.atlassian.net/wiki/spaces/PaymentsDirectionAPIStandardsDevelopment/pages/1612840961/Technical+Decision+-+048+-+RFC7519+Claims+in+login+hint+token+and+JWT+best+practices), which was to include the RFC7519 registered JWT claims as optional in `login_hint_token`.  
Additionally, the common JOSE header schema as been updated to include `jku` as per [the Security Profile JOSE header](https://paymentsnz.atlassian.net/wiki/spaces/PaymentsDirectionAPIStandardsDevelopment/pages/1581811168/NZ+Banking+Data+Security+Profile+v3.0.0-draft2#Step-2%3A-Form-the-JOSE-Header) guidance.  Previously the schema lacked the ability to include this header, as documented in [RFC7515 claim](https://www.rfc-editor.org/rfc/rfc7515.html#section-4.1.2)